### PR TITLE
HouseKeeping-0.0.5: added `.gitignore` to ignore `*.html`files

### DIFF
--- a/src/python/scrapy framework based scrapers/tutorial/.gitignore
+++ b/src/python/scrapy framework based scrapers/tutorial/.gitignore
@@ -1,0 +1,19 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Clojure template
+pom.xml
+pom.xml.asc
+*jar
+/lib/
+/classes/
+/target/
+/checkouts/
+.lein-deps-sum
+.lein-repl-history
+.lein-plugins/
+.lein-failures
+.nrepl-port
+*.ipynb_checkpoints
+
+.Rproj.user
+*.cpython-36.pyc
+*.html


### PR DESCRIPTION
added `.gitignore` to ignore `*.html` in `\src\python\scrapy framework based scrapers\tutorial` location